### PR TITLE
Introducing Zjl37/jwc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 
 ### 课表
 
+- [Zjl37/jwc.py](https://github.com/Zjl37/jwc.py)：教务课表转 ICS；大物实验排课辅助
 - [rewired-gh/hitsz_course_schedule_ics_converter](https://github.com/rewired-gh/hitsz_course_schedule_ics_converter)：自动获取与 ICS 生成脚本
 - [doby.tech](https://doby.tech)：课表 CalDAV 服务平台
 - [StupidTrees/HITA_X](https://github.com/StupidTrees/HITA_X)：Android 课表 app


### PR DESCRIPTION
动量神蚣（jwc.py）是一个 CLI 应用，可以代你从 HITSZ 的教务网站上获取课表信息，将其转换为 iCalendar 日历文件，从而可以方便地导入各种日历应用。此外还附带一些其他功能。
